### PR TITLE
Some proposals for mojaloop/helm PR #144

### DIFF
--- a/mojaloop-simulator/templates/_helpers.tpl
+++ b/mojaloop-simulator/templates/_helpers.tpl
@@ -12,7 +12,7 @@ We prefix deployment components with the release name by default.
 This can be overridden by setting .Values.prefix value to empty string.
 Prefix is limited to 10 characters long.
 */}}
-{{- define "prefix" -}}
+{{- define "mojaloop-simulator.prefix" -}}
 {{- if kindIs "invalid" .Values.prefix -}}
 {{- printf "%s-" .Release.Name | trunc 10 -}}
 {{- else -}}

--- a/mojaloop-simulator/templates/config-jws-public-keys.yaml
+++ b/mojaloop-simulator/templates/config-jws-public-keys.yaml
@@ -1,9 +1,8 @@
-{{ $config := merge .Values $.Values.defaults }}
 {{- if .Values.simulators }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "prefix" . }}jws-public-keys
+  name: {{ include "mojaloop-simulator.prefix" . }}jws-public-keys
   labels:
     app: sim
     chart: {{ template "mojaloop-simulator.chart" $ }}

--- a/mojaloop-simulator/templates/config-rules.yaml
+++ b/mojaloop-simulator/templates/config-rules.yaml
@@ -1,12 +1,12 @@
-{{- $prefix := include "prefix" . }}
 {{- range $name, $customConfig := .Values.simulators }}
 {{- $config := merge $customConfig $.Values.defaults }}
+{{- $fullName := printf "%s%s" (include "mojaloop-simulator.prefix" $) $name -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ $prefix }}{{ $name }}-rules
+  name: {{ $fullName }}-rules
   labels:
-    app: {{ $prefix }}{{ $name }}
+    app: {{ $fullName }}
     chart: {{ template "mojaloop-simulator.chart" $ }}
     release: {{ $.Release.Name }}
     heritage: {{ $.Release.Service }}

--- a/mojaloop-simulator/templates/deployment.yaml
+++ b/mojaloop-simulator/templates/deployment.yaml
@@ -1,26 +1,27 @@
-{{- $prefix := include "prefix" . -}}
+{{- $prefix := include "mojaloop-simulator.prefix" . -}}
 {{- range $name, $customConfig := .Values.simulators }}
+{{- $fullName := printf "%s%s" $prefix $name }}
 {{- $config := merge $customConfig $.Values.defaults }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ $prefix }}{{ $name }}-scheme-adapter
+  name: {{ $fullName }}-scheme-adapter
   labels:
-    app.kubernetes.io/name: {{ $prefix }}{{ $name }}-scheme-adapter
+    app.kubernetes.io/name: {{ $fullName }}-scheme-adapter
     app.kubernetes.io/instance: {{ $.Release.Name }}
-    app.kubernetes.io/version: {{ $.Chart.AppVersion }}
+    app.kubernetes.io/version: "{{ $.Chart.AppVersion }}"
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
     helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version | replace "+" "_" }}
 spec:
   replicas: {{ $config.replicaCount }}
   selector:
     matchLabels:
-      app: {{ $prefix }}{{ $name }}-scheme-adapter
+      app: {{ $fullName }}-scheme-adapter
       release: {{ $.Release.Name }}
   template:
     metadata:
       labels:
-        app: {{ $prefix }}{{ $name }}-scheme-adapter
+        app: {{ $fullName }}-scheme-adapter
         release: {{ $.Release.Name }}
     spec:
       volumes:
@@ -30,7 +31,7 @@ spec:
           {{- if $config.config.schemeAdapter.secrets.jws.privKeySecretName }}
           secretName: {{ $config.config.schemeAdapter.secrets.jws.privKeySecretName }}
           {{- else }}
-          secretName: {{ $prefix }}{{ $name }}-jws-priv-key
+          secretName: {{ $fullName }}-jws-priv-key
           {{- end }}
       {{- end }}
       - name: jws-public-keys
@@ -45,7 +46,7 @@ spec:
           {{- if $config.config.schemeAdapter.secrets.tlsSecretName }}
           secretName: {{ $config.config.schemeAdapter.secrets.tlsSecretName }}
           {{- else }}
-          secretName: sim-{{ $name }}-tls-creds
+          secretName: {{ $fullName }}-tls-creds
           {{- end }}
       {{- if $config.config.schemeAdapter.initContainers }}
       initContainers:
@@ -90,11 +91,11 @@ spec:
           mountPath: "/secrets/"
         env:
         - name: CACHE_HOST
-          value: {{ printf "%s%s-cache" $prefix $name }}
+          value: {{ printf "%s-cache" $fullName }}
         - name: BACKEND_ENDPOINT
-          value: {{ printf "%s%s-backend:3000" $prefix $name }}
+          value: {{ printf "%s-backend:3000" $fullName }}
         - name: DFSP_ID
-          value: {{ $name | quote }}
+          value: {{ $fullName | quote }}
         - name: IN_CA_CERT_PATH
           value: "./secrets/cacert.pem"
         - name: IN_SERVER_CERT_PATH
@@ -138,9 +139,9 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ $prefix }}{{ $name }}-backend
+  name: {{ $fullName }}-backend
   labels:
-    app: {{ $prefix }}{{ $name }}-backend
+    app: {{ $fullName }}-backend
     chart: {{ template "mojaloop-simulator.chart" $ }}
     release: {{ $.Release.Name }}
     heritage: {{ $.Release.Service }}
@@ -148,12 +149,12 @@ spec:
   replicas: {{ $config.replicaCount }}
   selector:
     matchLabels:
-      app: {{ $prefix }}{{ $name }}-backend
+      app: {{ $fullName }}-backend
       release: {{ $.Release.Name }}
   template:
     metadata:
       labels:
-        app: {{ $prefix }}{{ $name }}-backend
+        app: {{ $fullName }}-backend
         release: {{ $.Release.Name }}
     spec:
       {{- if $config.config.backend.initContainers }}
@@ -190,11 +191,11 @@ spec:
         {{- end }}
         env:
         - name: OUTBOUND_ENDPOINT
-          value: "http://{{ $prefix }}{{ $name }}-scheme-adapter:{{ $config.config.schemeAdapter.env.OUTBOUND_LISTEN_PORT }}"
+          value: "http://{{ $fullName }}-scheme-adapter:{{ $config.config.schemeAdapter.env.OUTBOUND_LISTEN_PORT }}"
         - name: SCHEME_NAME
-          value: {{ $name | quote }}
+          value: {{ $fullName | quote }}
         - name: DFSP_ID
-          value: {{ $name | quote }}
+          value: {{ $fullName | quote }}
         {{- range $k, $v := $config.config.backend.env }}
         - name: {{ $k }}
           value: {{ $v | quote }}
@@ -207,7 +208,7 @@ spec:
       volumes:
       - name: {{ $prefix }}rules
         configMap:
-          name: {{ $prefix }}{{ $name }}-rules
+          name: {{ $fullName }}-rules
       imagePullSecrets:
         - name: {{ $config.config.imagePullSecretName }}
     {{- with $config.nodeSelector }}
@@ -227,9 +228,9 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ $prefix }}{{ $name }}-cache
+  name: {{ $fullName }}-cache
   labels:
-    app: {{ $prefix }}{{ $name }}-cache
+    app: {{ $fullName }}-cache
     chart: {{ template "mojaloop-simulator.chart" $ }}
     release: {{ $.Release.Name }}
     heritage: {{ $.Release.Service }}
@@ -237,12 +238,12 @@ spec:
   replicas: {{ $config.replicaCount }}
   selector:
     matchLabels:
-      app: {{ $prefix }}{{ $name }}-cache
+      app: {{ $fullName }}-cache
       release: {{ $.Release.Name }}
   template:
     metadata:
       labels:
-        app: {{ $prefix }}{{ $name }}-cache
+        app: {{ $fullName }}-cache
         release: {{ $.Release.Name }}
     spec:
       containers:

--- a/mojaloop-simulator/templates/horizontalpodautoscaler.yaml
+++ b/mojaloop-simulator/templates/horizontalpodautoscaler.yaml
@@ -1,13 +1,13 @@
-{{- $prefix := include "prefix" . -}}
 {{- range $name, $customConfig := .Values.simulators }}
 {{- $config := merge $customConfig $.Values.defaults }}
+{{- $fullName := printf "%s%s" (include "mojaloop-simulator.prefix" $) $name -}}
 {{- if $config.config.schemeAdapter.scale.enabled }}
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ $prefix }}{{ $name }}-scheme-adapter
+  name: {{ $fullName }}-scheme-adapter
   labels:
-    app: {{ $prefix }}{{ $name }}-scheme-adapter
+    app: {{ $fullName }}-scheme-adapter
     chart: {{ template "mojaloop-simulator.chart" $ }}
     release: {{ $.Release.Name }}
     heritage: {{ $.Release.Service }}
@@ -15,7 +15,7 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ $prefix }}{{ $name }}-scheme-adapter
+    name: {{ $fullName }}-scheme-adapter
 {{ $config.config.schemeAdapter.scale.spec | toYaml | indent 2 }}
 ---
 {{- end }}

--- a/mojaloop-simulator/templates/ingress.yaml
+++ b/mojaloop-simulator/templates/ingress.yaml
@@ -1,5 +1,4 @@
 {{ if .Values.simulators }}
-{{- $prefix := include "prefix" . -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -16,27 +15,28 @@ metadata:
 spec:
   rules:
   {{- range $name, $customConfig := .Values.simulators }}
+  {{- $fullName := printf "%s%s" (include "mojaloop-simulator.prefix" $) $name -}}
   {{- $config := merge $customConfig $.Values.defaults }}
   {{- if $config.ingress.enabled -}}
     {{- range $host := $config.ingress.hosts }}
       - host: {{ $host }}
         http:
           paths:
-          - path: /sim/{{ $name }}/outbound{{ $.Values.ingress.ingressPathRewriteRegex }}
+          - path: /sim/{{ $fullName }}/outbound{{ $.Values.ingress.ingressPathRewriteRegex }}
             backend:
-              serviceName: {{ $prefix }}{{ $name }}-scheme-adapter
+              serviceName: {{ $fullName }}-scheme-adapter
               servicePort: outboundapi
-          - path: /sim/{{ $name }}/inbound{{ $.Values.ingress.ingressPathRewriteRegex }}
+          - path: /sim/{{ $fullName }}/inbound{{ $.Values.ingress.ingressPathRewriteRegex }}
             backend:
-              serviceName: {{ $prefix }}{{ $name }}-scheme-adapter
+              serviceName: {{ $fullName }}-scheme-adapter
               servicePort: inboundapi
-          - path: /sim/{{ $name }}/sdktest{{ $.Values.ingress.ingressPathRewriteRegex }}
+          - path: /sim/{{ $fullName }}/sdktest{{ $.Values.ingress.ingressPathRewriteRegex }}
             backend:
-              serviceName: sim-{{ $name }}-scheme-adapter
+              serviceName: {{ $fullName }}-scheme-adapter
               servicePort: testapi
-          - path: /sim/{{ $name }}/test{{ $.Values.ingress.ingressPathRewriteRegex }}
+          - path: /sim/{{ $fullName }}/test{{ $.Values.ingress.ingressPathRewriteRegex }}
             backend:
-              serviceName: {{ $prefix }}{{ $name }}-backend
+              serviceName: {{ $fullName }}-backend
               servicePort: testapi
     {{- end }}
   {{- end }}

--- a/mojaloop-simulator/templates/secret.yaml
+++ b/mojaloop-simulator/templates/secret.yaml
@@ -1,13 +1,13 @@
-{{- $prefix := include "prefix" . -}}
 {{- range $name, $customConfig := .Values.simulators }}
 {{- $config := merge $customConfig $.Values.defaults }}
+{{- $fullName := printf "%s%s" (include "mojaloop-simulator.prefix" $) $name -}}
 {{- if $config.config.schemeAdapter.env.JWS_SIGN }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ $prefix }}{{ $name }}-jws-priv-key
+  name: {{ $fullName }}-jws-priv-key
   labels:
-    app: {{ $prefix }}{{ $name }}
+    app: {{ $fullName }}
     chart: {{ template "mojaloop-simulator.chart" $ }}
     release: {{ $.Release.Name }}
     heritage: {{ $.Release.Service }}
@@ -24,15 +24,15 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: sim-{{ $name }}-tls-creds
+  name: {{ $fullName }}-tls-creds
   labels:
-    app: sim-{{ $name }}
+    app: {{ $fullName }}
     chart: {{ template "mojaloop-simulator.chart" $ }}
     release: {{ $.Release.Name }}
     heritage: {{ $.Release.Service }}
 data:
-  {{- $ca := genCA "sim-${name}-scheme-adapter" 3650 }}
-  {{- $cert := genSignedCert "sim-${name}-scheme-adapter" nil nil 3650 $ca }}
+  {{- $ca := genCA (printf "%s-scheme-adapter" $fullName) 3650 }}
+  {{- $cert := genSignedCert (printf "%s-scheme-adapter" $fullName) nil nil 3650 $ca }}
   "cacert.pem": {{ $ca.Cert | b64enc }}
   "servercert.pem": {{ $cert.Cert | b64enc }}
   "serverkey.pem": {{ $cert.Key | b64enc }}

--- a/mojaloop-simulator/templates/service.yaml
+++ b/mojaloop-simulator/templates/service.yaml
@@ -1,12 +1,12 @@
-{{- $prefix := include "prefix" . -}}
 {{- range $name, $customConfig := .Values.simulators }}
 {{- $config := merge $customConfig $.Values.defaults }}
+{{- $fullName := printf "%s%s" (include "mojaloop-simulator.prefix" $) $name -}}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ $prefix }}{{ $name }}-backend
+  name: {{ $fullName }}-backend
   labels:
-    app: {{ $prefix }}{{ $name }}-backend
+    app: {{ $fullName }}-backend
     chart: {{ template "mojaloop-simulator.chart" $ }}
     release: {{ $.Release.Name }}
     heritage: {{ $.Release.Service }}
@@ -26,15 +26,15 @@ spec:
        name: testapi
        targetPort: testapi
    selector:
-     app: {{ $prefix }}{{ $name }}-backend
+     app: {{ $fullName }}-backend
      release: {{ $.Release.Name }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ $prefix }}{{ $name }}-scheme-adapter
+  name: {{ $fullName }}-scheme-adapter
   labels:
-    app: {{ $prefix }}{{ $name }}-scheme-adapter
+    app: {{ $fullName }}-scheme-adapter
     chart: {{ template "mojaloop-simulator.chart" $ }}
     release: {{ $.Release.Name }}
     heritage: {{ $.Release.Service }}
@@ -56,16 +56,16 @@ spec:
        targetPort: testapi
      {{- end }}
    selector:
-     app: {{ $prefix }}{{ $name }}-scheme-adapter
+     app: {{ $fullName }}-scheme-adapter
      release: {{ $.Release.Name }}
 ---
 {{- if $config.config.cache.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ $prefix }}{{ $name }}-cache
+  name: {{ $fullName }}-cache
   labels:
-    app: {{ $prefix }}{{ $name }}-cache
+    app: {{ $fullName }}-cache
     chart: {{ template "mojaloop-simulator.chart" $ }}
     release: {{ $.Release.Name }}
     heritage: {{ $.Release.Service }}
@@ -77,7 +77,7 @@ spec:
        name: redis
        targetPort: redis
    selector:
-     app: {{ $prefix }}{{ $name }}-cache
+     app: {{ $fullName }}-cache
      release: {{ $.Release.Name }}
 {{- end }}
 ---

--- a/mojaloop-simulator/values.yaml
+++ b/mojaloop-simulator/values.yaml
@@ -140,7 +140,7 @@ sharedJWSPubKeys:
 defaults: &defaults
   # Changes to this object in the parent chart, for example 'mojaloop-simulator.defaults' will be
   # applied to all simulators deployed by this child chart.
-  config:    
+  config:
     imagePullSecretName: dock-casa-secret
 
     cache:


### PR DESCRIPTION
- Implemented combined `fullName` template
- Updated the PR to address some changes that have occurred since the PR was originally made
- Quoted label `app.kubernetes.io/version` as the required type is string
- Templates are global (not chart-global, but _global_), so renamed `prefix` template to `mojaloop-simulator.prefix`